### PR TITLE
Fix zoom overlapping

### DIFF
--- a/src/TablePlain.tsx
+++ b/src/TablePlain.tsx
@@ -66,7 +66,7 @@ export class TablePlain extends React.Component<TableProps, IState> {
 
   renderRoot = (children: React.ReactNode) => {
     const Root: any = this.rootElement;
-    return <Root style={{ tableLayout: "fixed" }}>{children}</Root>;
+    return <Root style={{ tableLayout: "auto" }}>{children}</Root>;
   };
 
   renderData(colDef: IColDef[], data: any[]) {

--- a/src/__tests__/__snapshots__/TablePlain.test.tsx.snap
+++ b/src/__tests__/__snapshots__/TablePlain.test.tsx.snap
@@ -41,7 +41,7 @@ ShallowWrapper {
         <tbody />
       </React.Fragment>,
       "style": Object {
-        "tableLayout": "fixed",
+        "tableLayout": "auto",
       },
     },
     "ref": null,
@@ -122,7 +122,7 @@ ShallowWrapper {
           <tbody />
         </React.Fragment>,
         "style": Object {
-          "tableLayout": "fixed",
+          "tableLayout": "auto",
         },
       },
       "ref": null,


### PR DESCRIPTION
Text in header and content was overlapping
happend in combination with react-table-mui and browser zoom